### PR TITLE
fix assets path in Rails context

### DIFF
--- a/lib/sass_inline_svg.rb
+++ b/lib/sass_inline_svg.rb
@@ -16,7 +16,7 @@ module Sass::Script::Functions
 
     # Use Rails asset pipeline if in Rails context:
     if defined?(Rails)
-      path = Rails.application.assets[path]
+      path = Rails.application.assets[path].pathname
     end
 
     svg = _readFile(path).strip


### PR DESCRIPTION
Hi this tiny patch fixes inline svg in Rails context:

`Rails.application.assets[path]` returns `Sprockets::Asset`, which when called `File.readable?` on it will throw `TypeError: no implicit conversion of Sprockets::Asset into String`;

while `Sprockets::Asset#pathname` returns a Pathname object, which works fine

Also in my settings I will have to use `inline_svg` instead of `inline-svg` as advertised.
